### PR TITLE
fix: Forgotten import for page-container

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -10,6 +10,7 @@ export * from "./form"
 export * from "./icons"
 export * from "./nav"
 export * from "./option-card"
+export * from "./page-container"
 export * from "./steps"
 export * from "./txn-expire-text"
 


### PR DESCRIPTION
## Description

The `page-container` component was not included in the `src/components/index.ts` file, making it unavailable to import from Alberto (it's not used in Gwen).
